### PR TITLE
go template for testing environment variables

### DIFF
--- a/go/envs/go.mod
+++ b/go/envs/go.mod
@@ -1,0 +1,5 @@
+module function
+
+go 1.16
+
+require github.com/cloudevents/sdk-go/v2 v2.5.0

--- a/go/envs/handle.go
+++ b/go/envs/handle.go
@@ -1,0 +1,26 @@
+package function
+/*
+This function template responds with a list of environment variables that starts with TEST_
+The template is meant to be used in by `func config envs` e2e test
+*/
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
+	res.Header().Add("Content-Type", "text/plain")
+	testEnvVars := []string{}
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "TEST_") {
+			testEnvVars = append(testEnvVars, e)
+		}
+	}
+	_, err := fmt.Fprintf(res, "%v\n", strings.Join(testEnvVars, "\n"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error or response write: %v", err)
+	}
+}


### PR DESCRIPTION
New go template that just returns on default endpoint a list of environment variables that starts with `TEST_`.
The template is intended to be used by a `func config envs` e2e test (Draft PR to be pushed soon on knative-sandbox/kn-plugin-func for review)