### PR TITLE
go template for testing volumes

### DIFF
--- a/go/volumes/go.mod
+++ b/go/volumes/go.mod
@@ -1,0 +1,5 @@
+module function
+
+go 1.16
+
+require github.com/cloudevents/sdk-go/v2 v2.5.0

--- a/go/volumes/handle.go
+++ b/go/volumes/handle.go
@@ -1,0 +1,34 @@
+package function
+/*
+This function template returns on body the content of a file on the server
+The template is meant to be used in by `func config volumes` e2e test
+*/
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"net/http"
+	"strings"
+)
+
+func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
+	res.Header().Add("Content-Type", "text/plain")
+
+	// v=/test/volume-config/myconfig
+	q := strings.Split(req.URL.RawQuery, "=")
+	action := q[0]
+	path := q[1]
+
+	if action == "v" {
+		b, err := ioutil.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error reading file: %v", err)
+		}
+		_, err = fmt.Fprintf(res, "%v", string(b))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error on response write: %v", err)
+		}
+	}
+
+}


### PR DESCRIPTION
A template in go that returns the content of a file. It is meant to be used by an upcoming e2e test for func config volumes. 