### PR TITLE
refactor: add manifest.yaml

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,15 @@
+# Required. One or more Buildpack builder image names capable of transforming
+# this language pack's function source code into a container image. These values
+# are copied directly to a function project's func.yaml file, allowing the
+# function developer to choose between them in local build configurations
+builders:
+  default: gcr.io/paketo-buildpacks/builder:base
+  base: gcr.io/paketo-buildpacks/builder:base
+  full: gcr.io/paketo-buildpacks/builder:full
+
+# Optional. A list of additional Buildpacks to be applied to the language pack's
+# builder image when the function is built
+buildpacks:
+  - paketo-buildpacks/go-dist
+  - ghcr.io/boson-project/go-function-buildpack:tip
+


### PR DESCRIPTION
This file is needed as a result of a change in the `func` repo, landing in this PR https://github.com/knative-sandbox/kn-plugin-func/pull/561. That PR removed the default builders from the binary, such that any language pack/template repository must at least specify one builder.

Unfortunately, in that PR was a pointer to my fork of this repository. That needs to be changed when this lands.

Signed-off-by: Lance Ball <lball@redhat.com>