### PR TITLE
update volumes test template func

### DIFF
--- a/go/volumes/handle.go
+++ b/go/volumes/handle.go
@@ -1,27 +1,38 @@
 package function
+
 /*
-This function template returns on body the content of a file on the server
+This function template read and (optionally) write the content of a file on the server
 The template is meant to be used in by `func config volumes` e2e test
 */
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"net/http"
-	"strings"
+	"os"
 )
 
 func Handle(ctx context.Context, res http.ResponseWriter, req *http.Request) {
 	res.Header().Add("Content-Type", "text/plain")
 
 	// v=/test/volume-config/myconfig
-	q := strings.Split(req.URL.RawQuery, "=")
-	action := q[0]
-	path := q[1]
+	// w=hello
+	path := req.URL.Query().Get("v")
+	content := req.URL.Query().Get("w")
 
-	if action == "v" {
-		b, err := ioutil.ReadFile(path)
+	if path != "" {
+		if content != "" {
+			f, err := os.Create(path)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error creating file: %v\n", err)
+			} else {
+				defer f.Close()
+				err = os.WriteFile(path, []byte(content), 0644)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "error writing file: %v\n", err)
+				}
+			}
+		}
+		b, err := os.ReadFile(path)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error reading file: %v", err)
 		}


### PR DESCRIPTION
The existing test volume template is currently used on knative/func [e2e test](https://github.com/knative/func/blob/main/test/e2e/scenario_config-volumes_test.go#L108)  to test config maps and secrets by reading and comparing its [file content ](https://github.com/knative/func/blob/main/test/e2e/scenario_config-volumes_test.go#L163).

The change in this PR would help/allow future tests implementation to write simple content to files, useful to test **PersistentVolumeClaim** and **EmptyDir** options of `func config volumes add` 
